### PR TITLE
Multiple fixes for modern versions of compilers/interpeters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,18 @@ java -jar EntityFXBench.jar
 
 ### JavaScript
 
-Web:
+#### Web
 
 http://laseroid.azurewebsites.net/js-bench/
 
-NodeJS: TODO
+#### NodeJS
+
+You must have nodejs installed
+
+```sh
+cd src/js
+node ./node_main.js
+```
 
 ### PHP
 
@@ -83,3 +90,15 @@ lua main.lua
 ## Build
 
 TODO
+
+### Go
+```sh
+cd src/go/entityfx
+go build
+```
+
+alternatively:
+```sh
+go get -u github.com/EntityFX/EntityFX-Bench/src/go/entityfx
+```
+

--- a/src/go/entityfx/dhrystone/dhrystone.go
+++ b/src/go/entityfx/dhrystone/dhrystone.go
@@ -3,7 +3,7 @@ package dhrystone
 import (
 	"strings"
 
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 const (

--- a/src/go/entityfx/dhrystone/dhrystoneBenchmark.go
+++ b/src/go/entityfx/dhrystone/dhrystoneBenchmark.go
@@ -3,8 +3,8 @@ package dhrystone
 import (
 	"reflect"
 
-	g "../generic"
-	"../utils"
+	g "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/generic"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type DhrystoneBenchmark struct {

--- a/src/go/entityfx/generic/arithmetics.go
+++ b/src/go/entityfx/generic/arithmetics.go
@@ -1,7 +1,7 @@
 package generic
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type ArithmeticsBenchmark struct {

--- a/src/go/entityfx/generic/benchmark.go
+++ b/src/go/entityfx/generic/benchmark.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 var IterrationsRatio float64 = 1.0

--- a/src/go/entityfx/generic/callBenchmark.go
+++ b/src/go/entityfx/generic/callBenchmark.go
@@ -3,7 +3,7 @@ package generic
 import (
 	"runtime"
 
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type CallBenchmark struct {

--- a/src/go/entityfx/generic/hashBenchmark.go
+++ b/src/go/entityfx/generic/hashBenchmark.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type HashBenchmark struct {

--- a/src/go/entityfx/generic/ifElseBenchmark.go
+++ b/src/go/entityfx/generic/ifElseBenchmark.go
@@ -1,7 +1,7 @@
 package generic
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type IfElseBenchmark struct {

--- a/src/go/entityfx/generic/mathBenchmark.go
+++ b/src/go/entityfx/generic/mathBenchmark.go
@@ -1,6 +1,6 @@
 package generic
 
-import "../utils"
+import "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 
 import "math"
 

--- a/src/go/entityfx/generic/memoryBenchmark.go
+++ b/src/go/entityfx/generic/memoryBenchmark.go
@@ -1,7 +1,7 @@
 package generic
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type MemoryBenchmark struct {

--- a/src/go/entityfx/generic/randomMemoryBenchmark.go
+++ b/src/go/entityfx/generic/randomMemoryBenchmark.go
@@ -1,7 +1,7 @@
 package generic
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type RandomMemoryBenchmark struct {

--- a/src/go/entityfx/generic/stringManipulation.go
+++ b/src/go/entityfx/generic/stringManipulation.go
@@ -1,6 +1,6 @@
 package generic
 
-import "../utils"
+import "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 
 import "strings"
 

--- a/src/go/entityfx/go.mod
+++ b/src/go/entityfx/go.mod
@@ -1,0 +1,3 @@
+module github.com/EntityFX/EntityFX-Bench/src/go/entityfx
+
+go 1.17

--- a/src/go/entityfx/linpack/linpack.go
+++ b/src/go/entityfx/linpack/linpack.go
@@ -1,7 +1,7 @@
 package linpack
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type LinpackResult struct {

--- a/src/go/entityfx/linpack/linpackBenchmark.go
+++ b/src/go/entityfx/linpack/linpackBenchmark.go
@@ -3,8 +3,8 @@ package linpack
 import (
 	"reflect"
 
-	g "../generic"
-	"../utils"
+	g "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/generic"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type LinpackBenchmark struct {

--- a/src/go/entityfx/main.go
+++ b/src/go/entityfx/main.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"runtime"
 
-	"./dhrystone"
-	"./generic"
-	"./linpack"
-	"./scimark2"
-	"./utils"
-	"./whetstone"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/dhrystone"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/generic"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/linpack"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/scimark2"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/whetstone"
 )
 
 func writeResult(writer utils.WriterType, benchResult *generic.BenchResult) {

--- a/src/go/entityfx/scimark2/kernel.go
+++ b/src/go/entityfx/scimark2/kernel.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"math/rand"
 	"time"
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 func measureFFT(N int, mintime float64) float64 {

--- a/src/go/entityfx/scimark2/scimark2.go
+++ b/src/go/entityfx/scimark2/scimark2.go
@@ -1,7 +1,7 @@
 package scimark2
 
 import (
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type Scimark2Result struct {

--- a/src/go/entityfx/scimark2/scimark2Benchmark.go
+++ b/src/go/entityfx/scimark2/scimark2Benchmark.go
@@ -3,8 +3,8 @@ package scimark2
 import (
 	"reflect"
 
-	g "../generic"
-	"../utils"
+	g "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/generic"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type Scimark2Benchmark struct {

--- a/src/go/entityfx/whetstone/whetstone.go
+++ b/src/go/entityfx/whetstone/whetstone.go
@@ -3,7 +3,7 @@ package whetstone
 import (
 	"math"
 
-	"../utils"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 	//"strings"
 )
 

--- a/src/go/entityfx/whetstone/whetstoneBenchmark.go
+++ b/src/go/entityfx/whetstone/whetstoneBenchmark.go
@@ -3,8 +3,8 @@ package whetstone
 import (
 	"reflect"
 
-	g "../generic"
-	"../utils"
+	g "github.com/EntityFX/EntityFX-Bench/src/go/entityfx/generic"
+	"github.com/EntityFX/EntityFX-Bench/src/go/entityfx/utils"
 )
 
 type WhetstoneBenchmark struct {

--- a/src/lua/main.lua
+++ b/src/lua/main.lua
@@ -21,6 +21,10 @@ require "whetstone/whetstoneBenchmark"
 require "linpack/linpackBenchmark"
 require "scimark2/scimark2Benchmark"
 
+if _ENV then
+	unpack = table.unpack
+end
+
 function writeResult(writer, benchResult)
     writer:writeTitle("%-30s", benchResult.benchmarkName)
     writer:writeValue("%15d ms", benchResult.elapsed)

--- a/src/lua/whetstone/whetstone.lua
+++ b/src/lua/whetstone/whetstone.lua
@@ -46,7 +46,7 @@ function Whetstone:bench(getinput)
         xtra = 1
     end
     calibrate = 0
-    self:writeLine("\nUse %d  passes (x 100)", xtra)
+    self:writeLine("\nUse %.4f  passes (x 100)", xtra)
     self:writeLine("\n          %s Precision Lua Whetstone Benchmark", "Double")
     self:writeLine("\n                  %s", "")
     self:writeLine("\nLoop content                  Result              MFLOPS " .. "     MOPS   Seconds\n")

--- a/src/python/entityfx/benchmark_base.py
+++ b/src/python/entityfx/benchmark_base.py
@@ -6,8 +6,11 @@ from entityfx.writer import Writer
 import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 from concurrent.futures import ALL_COMPLETED, thread, wait
-from multiprocessing import Pool
 import multiprocessing
+try:
+    mp = multiprocessing.get_context('fork')
+except (AttributeError, ValueError):
+    mp = multiprocessing
 
 class BenchmarkBase(Benchamrk):
 
@@ -93,7 +96,7 @@ class BenchmarkBase(Benchamrk):
 
     def bench_in_parallel(self, buildFunc, benchFunc, setBenchResultFunc):
         self._use_console(False)
-        cpu_count = multiprocessing.cpu_count()
+        cpu_count = mp.cpu_count()
         BenchmarkBase._parallelContext = [{
             "benchFunc" : benchFunc,
             "setBenchResultFunc" : setBenchResultFunc,
@@ -105,7 +108,7 @@ class BenchmarkBase(Benchamrk):
             "buildData" : buildFunc()
         }, range(0, cpu_count)))
  
-        p = Pool(cpu_count)
+        p = mp.Pool(cpu_count)
         results = p.map(BenchmarkBase._parallelContextFunc, benchs)
         p.close()
         self._use_console(True)

--- a/src/python/entityfx/parallel_call_benchmark.py
+++ b/src/python/entityfx/parallel_call_benchmark.py
@@ -3,7 +3,10 @@ from entityfx.writer import Writer
 from entityfx.benchmark_base import BenchmarkBase
 import time
 import multiprocessing
-from multiprocessing import Pool
+try:
+    mp = multiprocessing.get_context('fork')
+except (AttributeError, ValueError):
+    mp = multiprocessing
 
 class ParallelCallBenchmark(CallBenchmarkBase):
 
@@ -32,7 +35,7 @@ class ParallelCallBenchmark(CallBenchmarkBase):
 
 
     def bench_in_parallel(self, buildFunc, benchFunc, setBenchResultFunc):
-        cpu_count = multiprocessing.cpu_count()
+        cpu_count = mp.cpu_count()
         BenchmarkBase._parallelContext = [{
             "benchFunc" : self._doCallBench,
             "setBenchResultFunc" : setBenchResultFunc,
@@ -44,7 +47,7 @@ class ParallelCallBenchmark(CallBenchmarkBase):
             "buildData" : buildFunc()
         }, range(0, cpu_count)))
  
-        p = Pool(cpu_count)
+        p = mp.Pool(cpu_count)
         results = p.map(ParallelCallBenchmark._parallelContextCallFunc, benchs)
         p.close()
         return results

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -25,11 +25,14 @@ from entityfx.hash_benchmark import HashBenchmark
 from entityfx.parallel_hash_benchmark import ParallelHashBenchmark
 from entityfx.writer import Writer
 
-import time
 import platform
 import multiprocessing
 import sys
 
+try:
+    mp = multiprocessing.get_context('fork')
+except (AttributeError, ValueError):
+    mp = multiprocessing
 
 writer = Writer("Output.log")
 
@@ -136,7 +139,7 @@ for r in filter(isNotParallel, result):
 
 writer.write_title(header_totals)
 writer.write_line()
-writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), multiprocessing.cpu_count(), 0)
+writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), mp.cpu_count(), 0)
 
 for r in filter(isNotParallel, result):
     writer.write_value(",{0:1.2f}", r["Points"])
@@ -154,7 +157,7 @@ for r in filter(isNotParallel, result):
 
 writer.write_title(header_totals)
 writer.write_line()
-writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), multiprocessing.cpu_count(), 0)
+writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), mp.cpu_count(), 0)
 
 for r in filter(isNotParallel, result):
     writer.write_value(",{0:1.2f}", r["Result"])
@@ -171,7 +174,7 @@ for r in result:
 
 writer.write_title(header_totals)
 writer.write_line()
-writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), multiprocessing.cpu_count(), 0)
+writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), mp.cpu_count(), 0)
 
 for r in result:
     writer.write_value(",{0:1.2f}", r["Points"])
@@ -189,7 +192,7 @@ for r in result:
 
 writer.write_title(header_totals)
 writer.write_line()
-writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), multiprocessing.cpu_count(), 0)
+writer.write_title("{0},{1} {2},{3},{4}", platform.platform(), platform.python_implementation(), platform.python_version(), mp.cpu_count(), 0)
 
 for r in result:
     writer.write_value(",{0:1.2f}", r["Result"])


### PR DESCRIPTION
- Fix lua benchmark, now it should run on both old versions of lua and modern one
- Fix python benchmark on modern macos
- Fix go benchmark (now it is easier to compile as it is go mod friendly)