### PR TITLE
lua: improve precision and fix calls benchmark

### DIFF
--- a/src/lua/benchmarkBase.lua
+++ b/src/lua/benchmarkBase.lua
@@ -11,7 +11,7 @@ BenchmarkBase.IterrationsRatio = 1;
 
 function BenchmarkBase:bench()
     self:beforeBench()
-    local start = os.time()
+    local start = os.clock()
     local res = self:benchImplementation()
     local result = self:populateResult(self:buildResult(start), res)
     self:doOutput(result)
@@ -53,7 +53,7 @@ function BenchmarkBase:benchImplementation()
 end
 
 function BenchmarkBase:buildResult(start)
-    local elapsed = (os.time() - start) * 1000
+    local elapsed = math.floor((os.clock() - start) * 1000)
     local tElapsed = 0
 
     if elapsed == 0 then

--- a/src/lua/dhrystone/dhrystone.lua
+++ b/src/lua/dhrystone/dhrystone.lua
@@ -249,7 +249,7 @@ function Dhrystone2:Proc0(loops)
     local IntLoc2 = 0
     local IntLoc3 = 0
 
-    local start = os.time()
+    local start = os.clock()
 
     for i=0,loops - 1 do
         self:Proc5()
@@ -284,7 +284,7 @@ function Dhrystone2:Proc0(loops)
         IntLoc1 = self:Proc2(IntLoc1)
     end
 
-    local benchtime = (os.time() - start) * 1000
+    local benchtime = (os.clock() - start) * 1000
     local loopsPerBenchtime = 0
     if ((benchtime == 0)) then
         loopsPerBenchtime = 0;

--- a/src/lua/generic/callBenchmark.lua
+++ b/src/lua/generic/callBenchmark.lua
@@ -10,7 +10,7 @@ end
 function CallBenchmark:bench()
     self:beforeBench()
     local call_time = self:doCallBench()
-    local result = self:populateResult(self:buildResult(os.time() - call_time.callTime), call_time)
+    local result = self:populateResult(self:buildResult(call_time.callTime), call_time)
     self:doOutput(result)
     self:afterBench(result)
     return result

--- a/src/lua/generic/callBenchmarkBase.lua
+++ b/src/lua/generic/callBenchmarkBase.lua
@@ -11,7 +11,7 @@ function CallBenchmarBase:doCall(i, b)
 end
 
 function CallBenchmarBase:doCallBench()
-    local start = os.time()
+    local start = os.clock()
     local elapsed1 = 0
     local elapsed2 = 0
     local i = 0
@@ -23,18 +23,18 @@ function CallBenchmarBase:doCallBench()
         a = z + z1 + 0.5;
     end
 
-    elapsed1 = (os.time() - start) * 1000
+    elapsed1 = (os.clock() - start) * 1000
     a = 0.0;
     i = 0;
-    start = os.time()
+    start = os.clock()
     for i=1,self.iterrations do
         a = self:doCall(a, 0.01)
     end
-    elapsed2 = (os.time() - start) * 1000
+    elapsed2 = (os.clock() - start) * 1000
 
-    self.output:write("Elapsed No Call: %d", elapsed1)
+    self.output:write("Elapsed No Call: %d", math.floor(elapsed1))
     self.output:writeLine()
-    self.output:write("Elapsed Call: %d", elapsed2)
+    self.output:write("Elapsed Call: %d", math.floor(elapsed2))
     self.output:writeLine()
     local callTime = 0
 
@@ -43,6 +43,6 @@ function CallBenchmarBase:doCallBench()
     else
         callTime = elapsed2 - elapsed1
     end
-    self.output:writeLine("Call time: %d", callTime)
+    self.output:writeLine("Call time: %d", math.floor(callTime))
     return { callTime = callTime / 1000, a = a }
 end

--- a/src/lua/generic/memoryBenchmarkBase.lua
+++ b/src/lua/generic/memoryBenchmarkBase.lua
@@ -88,7 +88,7 @@ function MemoryBenchmarkBase:measureArrayRandomRead(size)
             I[15] = array[idx + 15]
         end
     end
-    local elapsed = os.clock() * 1000 - start
+    local elapsed = math.floor(os.clock() * 1000 - start)
     return { mbPerSec = (iterInternal * #array * 8.0 / (elapsed / 1000.0) / 1024 / 1024), res = I }
 end
 
@@ -128,6 +128,6 @@ function MemoryBenchmarkBase:measureArrayRandomLongRead(size)
             I[7] = array[idx + 7]
         end
     end
-    local elapsed = os.clock() * 1000 - start
+    local elapsed = math.floor(os.clock() * 1000 - start)
     return { mbPerSec = (iterInternal * #array * 8.0 / (elapsed / 1000.0) / 1024 / 1024), res = I }
 end

--- a/src/lua/generic/randomMemoryBenchmarkBase.lua
+++ b/src/lua/generic/randomMemoryBenchmarkBase.lua
@@ -54,6 +54,6 @@ function RandomMemoryBenchmarkBase:measureArrayRandomRead(size)
             I = array[idx]
         end
     end
-    local elapsed = os.clock() * 1000 - start
+    local elapsed = math.floor(os.clock() * 1000 - start)
     return { mbPerSec = (iterInternal * #array * 8.0 / (elapsed / 1000.0) / 1024 / 1024), res = I }
 end


### PR DESCRIPTION
 * Use os.clock() instead of os.time(). It gives ms precision. This is
   not a best path, but better approach would require to use native C
   functions and implement platform-dependent variant of os.clock
 * Fix calls benchmark as it was substracting result form os.time, while
   it was already elapsed seconds and that produced extremely wrong
   results.